### PR TITLE
docs: headers might've already been sent when handler throws

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -234,7 +234,9 @@ http.createServer(async (req, res) => {
     // or
     Sentry.captureException(err);
 
-    res.writeHead(500, 'Internal Server Error').end();
+    if (!res.headersSent) {
+      res.writeHead(500, 'Internal Server Error').end();
+    } 
   }
 });
 ```

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -264,6 +264,10 @@ export interface HandlerOptions<
  *     console.error(err);
  *     // or
  *     Sentry.captureException(err);
+ * 
+ *     if (!res.headersSent) {
+ *       res.writeHead(500, 'Internal Server Error').end();
+ *     } 
  *   }
  * });
  * ```

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -264,8 +264,6 @@ export interface HandlerOptions<
  *     console.error(err);
  *     // or
  *     Sentry.captureException(err);
- *
- *     res.writeHead(500, 'Internal Server Error').end();
  *   }
  * });
  * ```

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -264,10 +264,10 @@ export interface HandlerOptions<
  *     console.error(err);
  *     // or
  *     Sentry.captureException(err);
- * 
+ *
  *     if (!res.headersSent) {
  *       res.writeHead(500, 'Internal Server Error').end();
- *     } 
+ *     }
  *   }
  * });
  * ```


### PR DESCRIPTION
Closes #13

EDIT by @enisdenjo: Changed the "closes" syntax to comply with [GitHub's "Linking a pull request to an issue using a keyword"](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).