### PR TITLE
feat(client): Async iterator for subscriptions

### DIFF
--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -636,3 +636,260 @@ describe('retries', () => {
     expect(retryFn).not.toHaveBeenCalled();
   });
 });
+
+describe('iterate', () => {
+  it('should iterate a single result query', async () => {
+    const { fetch } = createTFetch();
+
+    const client = createClient({
+      url: 'http://localhost',
+      fetchFn: fetch,
+      retryAttempts: 0,
+    });
+
+    const iterator = client.iterate({
+      query: '{ getValue }',
+    });
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": false,
+        "value": {
+          "data": {
+            "getValue": "value",
+          },
+        },
+      }
+    `);
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": true,
+        "value": undefined,
+      }
+    `);
+  });
+
+  it('should iterate over subscription events', async () => {
+    const { fetch } = createTFetch();
+
+    const client = createClient({
+      url: 'http://localhost',
+      fetchFn: fetch,
+      retryAttempts: 0,
+    });
+
+    const iterator = client.iterate({
+      query: 'subscription { greetings }',
+    });
+
+    // Hi
+    await expect(iterator.next()).resolves.toBeDefined();
+    // Bonjour
+    await expect(iterator.next()).resolves.toBeDefined();
+    // Hola
+    await expect(iterator.next()).resolves.toBeDefined();
+    // Ciao
+    await expect(iterator.next()).resolves.toBeDefined();
+    // Zdravo
+    await expect(iterator.next()).resolves.toBeDefined();
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": true,
+        "value": undefined,
+      }
+    `);
+  });
+
+  it('should report execution errors to iterator', async () => {
+    const { fetch } = createTFetch();
+
+    const client = createClient({
+      url: 'http://localhost',
+      fetchFn: fetch,
+      retryAttempts: 0,
+    });
+
+    const iterator = client.iterate({
+      query: '{ throw }',
+    });
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": false,
+        "value": {
+          "errors": [
+            {
+              "locations": [
+                {
+                  "column": 3,
+                  "line": 1,
+                },
+              ],
+              "message": "Cannot query field "throw" on type "Query".",
+            },
+          ],
+        },
+      }
+    `);
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": true,
+        "value": undefined,
+      }
+    `);
+  });
+
+  it('should throw in iterator connection errors', async () => {
+    const { fetch, dispose } = createTFetch();
+
+    const client = createClient({
+      fetchFn: fetch,
+      url: 'http://localhost',
+      retryAttempts: 0,
+    });
+
+    const pingKey = Math.random().toString();
+    const iterator = client.iterate({
+      query: `subscription { ping(key: "${pingKey}") }`,
+    });
+
+    pong(pingKey);
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": false,
+        "value": {
+          "data": {
+            "ping": "pong",
+          },
+        },
+      }
+    `);
+
+    await dispose();
+
+    await expect(iterator.next()).rejects.toMatchInlineSnapshot(
+      `[NetworkError: Connection closed while having active streams]`,
+    );
+  });
+
+  it('should complete subscription when iterator loop breaks', async () => {
+    const { fetch, waitForRequest } = createTFetch();
+
+    const client = createClient({
+      fetchFn: fetch,
+      url: 'http://localhost',
+      retryAttempts: 0,
+    });
+
+    const pingKey = Math.random().toString();
+    const iterator = client.iterate({
+      query: `subscription { ping(key: "${pingKey}") }`,
+    });
+    iterator.return = jest.fn(iterator.return);
+
+    const req = await waitForRequest();
+
+    setTimeout(() => pong(pingKey), 0);
+
+    for await (const val of iterator) {
+      expect(val).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "ping": "pong",
+          },
+        }
+      `);
+      break;
+    }
+
+    expect(iterator.return).toHaveBeenCalled();
+
+    expect(req.signal.aborted).toBeTruthy();
+  });
+
+  it('should complete subscription when iterator loop throws', async () => {
+    const { fetch, waitForRequest } = createTFetch();
+
+    const client = createClient({
+      fetchFn: fetch,
+      url: 'http://localhost',
+      retryAttempts: 0,
+    });
+
+    const pingKey = Math.random().toString();
+    const iterator = client.iterate({
+      query: `subscription { ping(key: "${pingKey}") }`,
+    });
+    iterator.return = jest.fn(iterator.return);
+
+    const req = await waitForRequest();
+
+    setTimeout(() => pong(pingKey), 0);
+
+    await expect(async () => {
+      for await (const val of iterator) {
+        expect(val).toMatchInlineSnapshot(`
+          {
+            "data": {
+              "ping": "pong",
+            },
+          }
+        `);
+        throw new Error(':)');
+      }
+    }).rejects.toBeDefined();
+
+    expect(iterator.return).toHaveBeenCalled();
+
+    expect(req.signal.aborted).toBeTruthy();
+  });
+
+  it('should complete subscription when calling return directly on iterator', async () => {
+    const { fetch, waitForRequest } = createTFetch();
+
+    const client = createClient({
+      fetchFn: fetch,
+      url: 'http://localhost',
+      retryAttempts: 0,
+    });
+
+    const pingKey = Math.random().toString();
+    const iterator = client.iterate({
+      query: `subscription { ping(key: "${pingKey}") }`,
+    });
+
+    const req = await waitForRequest();
+
+    pong(pingKey);
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": false,
+        "value": {
+          "data": {
+            "ping": "pong",
+          },
+        },
+      }
+    `);
+
+    await expect(iterator.return?.()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": true,
+        "value": undefined,
+      }
+    `);
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": true,
+        "value": undefined,
+      }
+    `);
+
+    expect(req.signal.aborted).toBeTruthy();
+  });
+});

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -712,7 +712,7 @@ describe('iterate', () => {
     });
 
     const iterator = client.iterate({
-      query: '{ throw }',
+      query: 'subscription { throwing }',
     });
 
     await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
@@ -723,11 +723,14 @@ describe('iterate', () => {
             {
               "locations": [
                 {
-                  "column": 3,
+                  "column": 16,
                   "line": 1,
                 },
               ],
-              "message": "Cannot query field "throw" on type "Query".",
+              "message": "Kaboom!",
+              "path": [
+                "throwing",
+              ],
             },
           ],
         },

--- a/src/client.ts
+++ b/src/client.ts
@@ -207,6 +207,13 @@ export interface Client {
     sink: Sink<ExecutionResult<Data, Extensions>>,
   ): () => void;
   /**
+   * Subscribes and iterates over emitted results from an SSE connection
+   * through the returned async iterator.
+   */
+  iterate<Data = Record<string, unknown>, Extensions = unknown>(
+    request: RequestParams,
+  ): AsyncIterableIterator<ExecutionResult<Data, Extensions>>;
+  /**
    * Dispose of the client, destroy connections and clean up resources.
    */
   dispose: () => void;
@@ -635,6 +642,73 @@ export function createClient<SingleConnection extends boolean = false>(
         .catch((err) => sink.error(err));
 
       return () => control.abort();
+    },
+    iterate(request) {
+      const pending: ExecutionResult<
+        // TODO: how to not use `any` and not have a redundant function signature?
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        any
+      >[] = [];
+      const deferred = {
+        done: false,
+        error: null as unknown,
+        resolve: () => {
+          // noop
+        },
+      };
+      const dispose = this.subscribe(request, {
+        next(val) {
+          pending.push(val);
+          deferred.resolve();
+        },
+        error(err) {
+          deferred.done = true;
+          deferred.error = err;
+          deferred.resolve();
+        },
+        complete() {
+          deferred.done = true;
+          deferred.resolve();
+        },
+      });
+
+      const iterator = (async function* iterator() {
+        for (;;) {
+          if (!pending.length) {
+            // only wait if there are no pending messages available
+            await new Promise<void>((resolve) => (deferred.resolve = resolve));
+          }
+          // first flush
+          while (pending.length) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            yield pending.shift()!;
+          }
+          // then error
+          if (deferred.error) {
+            throw deferred.error;
+          }
+          // or complete
+          if (deferred.done) {
+            return;
+          }
+        }
+      })();
+      iterator.throw = async (err) => {
+        if (!deferred.done) {
+          deferred.done = true;
+          deferred.error = err;
+          deferred.resolve();
+        }
+        return { done: true, value: undefined };
+      };
+      iterator.return = async () => {
+        dispose();
+        return { done: true, value: undefined };
+      };
+
+      return iterator;
     },
     dispose() {
       client.dispose();

--- a/website/src/pages/get-started.mdx
+++ b/website/src/pages/get-started.mdx
@@ -231,7 +231,7 @@ const client = createClient({
   for await (const event of subscription) {
     expect(event).toEqual({ greetings: 'Hi' });
 
-    // to complete a running subscription, simply break the iterator loop
+    // complete a running subscription by breaking the iterator loop
     break;
   }
 })();

--- a/website/src/pages/get-started.mdx
+++ b/website/src/pages/get-started.mdx
@@ -217,7 +217,8 @@ const client = createClient({
     query: '{ hello }',
   });
 
-  await expect(query.next()).resolves.toEqual({ hello: 'world' });
+  const { value } = await query.next();
+  expect(value).toEqual({ hello: 'world' });
 })();
 
 // subscription

--- a/website/src/pages/get-started.mdx
+++ b/website/src/pages/get-started.mdx
@@ -213,31 +213,26 @@ const client = createClient({
 
 // query
 (async () => {
-  for await (const result of client.iterate({
+  const query = client.iterate({
     query: '{ hello }',
-  })) {
+  });
+
+  for await (const result of query) {
     expect(result).toEqual({ hello: 'world' });
   }
 })();
 
 // subscription
 (async () => {
-  const onNext = () => {
-    /* handle incoming values */
-  };
-
-  let unsubscribe = () => {
-    /* complete the subscription */
-  };
-
   const subscription = client.iterate({
     query: 'subscription { greetings }',
   });
 
-  await expect(subscription.next()).resolves.toEqual({ greetings: 'Hi' });
+  for await (const event of subscription) {
+    expect(event).toEqual({ greetings: 'Hi' });
 
-  expect(onNext).toBeCalledTimes(5); // we say "Hi" in 5 languages
+    // to complete a running subscription, simply break the iterator loop
+    break;
+  }
 })();
-
-// or using the observable pattern
 ```

--- a/website/src/pages/get-started.mdx
+++ b/website/src/pages/get-started.mdx
@@ -213,21 +213,11 @@ const client = createClient({
 
 // query
 (async () => {
-  const result = await new Promise((resolve, reject) => {
-    let result;
-    client.subscribe(
-      {
-        query: '{ hello }',
-      },
-      {
-        next: (data) => (result = data),
-        error: reject,
-        complete: () => resolve(result),
-      },
-    );
-  });
-
-  expect(result).toEqual({ hello: 'world' });
+  for await (const result of client.iterate({
+    query: '{ hello }',
+  })) {
+    expect(result).toEqual({ hello: 'world' });
+  }
 })();
 
 // subscription
@@ -240,19 +230,14 @@ const client = createClient({
     /* complete the subscription */
   };
 
-  await new Promise((resolve, reject) => {
-    unsubscribe = client.subscribe(
-      {
-        query: 'subscription { greetings }',
-      },
-      {
-        next: onNext,
-        error: reject,
-        complete: resolve,
-      },
-    );
+  const subscription = client.iterate({
+    query: 'subscription { greetings }',
   });
+
+  await expect(subscription.next()).resolves.toEqual({ greetings: 'Hi' });
 
   expect(onNext).toBeCalledTimes(5); // we say "Hi" in 5 languages
 })();
+
+// or using the observable pattern
 ```

--- a/website/src/pages/get-started.mdx
+++ b/website/src/pages/get-started.mdx
@@ -217,9 +217,7 @@ const client = createClient({
     query: '{ hello }',
   });
 
-  for await (const result of query) {
-    expect(result).toEqual({ hello: 'world' });
-  }
+  await expect(query.next()).resolves.toEqual({ hello: 'world' });
 })();
 
 // subscription

--- a/website/src/pages/get-started.mdx
+++ b/website/src/pages/get-started.mdx
@@ -207,7 +207,7 @@ export default {
 import { createClient } from 'graphql-sse';
 
 const client = createClient({
-  // singleConnection: true, preferred for HTTP/1 enabled servers. read more below
+  // singleConnection: true, preferred for HTTP/1 enabled servers and subscription heavy apps
   url: 'http://localhost:4000/graphql/stream',
 });
 

--- a/website/src/pages/recipes.mdx
+++ b/website/src/pages/recipes.mdx
@@ -47,55 +47,8 @@ const client = createClient({
   url: 'http://iterators.ftw:4000/graphql/stream',
 });
 
-export function subscribe(payload) {
-  let deferred = null;
-  const pending = [];
-  let throwMe = null,
-    done = false;
-  const dispose = client.subscribe(payload, {
-    next: (data) => {
-      pending.push(data);
-      deferred?.resolve(false);
-    },
-    error: (err) => {
-      throwMe = err;
-      deferred?.reject(throwMe);
-    },
-    complete: () => {
-      done = true;
-      deferred?.resolve(true);
-    },
-  });
-  return {
-    [Symbol.asyncIterator]() {
-      return this;
-    },
-    async next() {
-      if (done) return { done: true, value: undefined };
-      if (throwMe) throw throwMe;
-      if (pending.length) return { value: pending.shift() };
-      return (await new Promise(
-        (resolve, reject) => (deferred = { resolve, reject }),
-      ))
-        ? { done: true, value: undefined }
-        : { value: pending.shift() };
-    },
-    async throw(err) {
-      throwMe = err;
-      deferred?.reject(throwMe);
-      return { done: true, value: undefined };
-    },
-    async return() {
-      done = true;
-      deferred?.resolve(true);
-      dispose();
-      return { done: true, value: undefined };
-    },
-  };
-}
-
 (async () => {
-  const subscription = subscribe({
+  const subscription = client.iterate({
     query: 'subscription { greetings }',
   });
   // subscription.return() to dispose

--- a/website/src/pages/recipes.mdx
+++ b/website/src/pages/recipes.mdx
@@ -13,23 +13,13 @@ const client = createClient({
   url: 'http://hey.there:4000/graphql/stream',
 });
 
-export async function execute<T>(payload: RequestParams) {
-  return new Promise<T>((resolve, reject) => {
-    let result: T;
-    client.subscribe<T>(payload, {
-      next: (data) => (result = data),
-      error: reject,
-      complete: () => resolve(result),
-    });
-  });
-}
-
-// use
 (async () => {
+  const query = client.iterate({
+    query: '{ hello }',
+  });
+
   try {
-    const result = await execute({
-      query: '{ hello }',
-    });
+    const result = await query.next();
     // complete
     // next = result = { data: { hello: 'Hello World!' } }
   } catch (err) {
@@ -51,10 +41,11 @@ const client = createClient({
   const subscription = client.iterate({
     query: 'subscription { greetings }',
   });
-  // subscription.return() to dispose
+  // "subscription.return()" to dispose
 
   for await (const result of subscription) {
     // next = result = { data: { greetings: 5x } }
+    // "break" to dispose
   }
   // complete
 })();

--- a/website/src/pages/recipes.mdx
+++ b/website/src/pages/recipes.mdx
@@ -19,9 +19,9 @@ const client = createClient({
   });
 
   try {
-    const result = await query.next();
+    const { value } = await query.next();
+    // next = value = { data: { hello: 'Hello World!' } }
     // complete
-    // next = result = { data: { hello: 'Hello World!' } }
   } catch (err) {
     // error
   }


### PR DESCRIPTION
The `iterate` method on the client allows async iteration over the subscription events.

```js
import { createClient } from 'graphql-sse';

const client = createClient({
  // singleConnection: true, preferred for HTTP/1 enabled servers and subscription heavy apps
  url: 'http://localhost:4000/graphql/stream',
});

// query
(async () => {
  const query = client.iterate({
    query: '{ hello }',
  });

  const { value } = await query.next();
  expect(value).toEqual({ hello: 'world' });
})();

// subscription
(async () => {
  const subscription = client.iterate({
    query: 'subscription { greetings }',
  });

  for await (const event of subscription) {
    expect(event).toEqual({ greetings: 'Hi' });

    // complete a running subscription by breaking the iterator loop
    break;
  }
})();
```

### TODO

- [ ] ~Overload `subscribe` method~ https://github.com/microsoft/TypeScript/issues/54354